### PR TITLE
Fixes for v18

### DIFF
--- a/s6r_unit_tests/tests/__init__.py
+++ b/s6r_unit_tests/tests/__init__.py
@@ -1,6 +1,9 @@
 # Copyright 2023 Scalizer (<https://www.scalizer.fr>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from . import runner
-from . import loader
-from . import common
+# in v18+, trying to import odoo.tests when test_enable is False will print a logger.error
+from odoo.tools import config
+if config['test_enable']:
+    from . import runner
+    from . import loader
+    from . import common

--- a/s6r_unit_tests/tests/loader.py
+++ b/s6r_unit_tests/tests/loader.py
@@ -1,6 +1,5 @@
 # Copyright 2023 Scalizer (<https://www.scalizer.fr>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-
 from odoo.tests import loader
 import logging
 from .runner import skip_unit_test
@@ -9,9 +8,11 @@ _logger = logging.getLogger(__name__)
 run_suite_origin = loader.run_suite
 
 
-def run_suite(suite, module_name=None):
-    suite._tests = list(filter(lambda t: not skip_unit_test(t), suite._tests))
-    return run_suite_origin(suite, module_name)
-
+def run_suite(suite):
+    tests_to_skip = list(filter(lambda t: skip_unit_test(t), suite._tests))
+    for test in tests_to_skip:
+        _logger.info(f"Skipping unit test: {test}")
+        suite._tests.remove(test)
+    return run_suite_origin(suite)
 
 loader.run_suite = run_suite


### PR DESCRIPTION
### Pb rencontrés
- en v18, importer le module odoo.tests en dehors du mode test défini par `--test-enable` logue une erreur
    => je propose de gérer ce cas directement dans `tests/__init__.py`
- en v18, la fonction run_suite() ne prends qu'un argument

### Improvements
- ajouté la liste des tests skippés dans les logs